### PR TITLE
changed absolute pathname for bad pixel map

### DIFF
--- a/IDL/badpix.pro
+++ b/IDL/badpix.pro
@@ -164,7 +164,7 @@ bp:
 ; cleaning using the bad pixel mask
 ;********************************************
 
-bp_mask=MRDFITS('~/WISPIPE/aXe/CONFIG/bp_mask_v5.fits',0,/silent)
+bp_mask=MRDFITS(getenv('WISPIPE')+'/aXe/CONFIG/bp_mask_v5.fits',0,/silent)
 bp_mask_2=bp_mask
 
 


### PR DESCRIPTION
It looks like bp_mask_v5.fits was still on an absolute path in badpix.pro