### PR TITLE
added path to direct images before axecore

### DIFF
--- a/aXe/G102_axe_V6_2.py
+++ b/aXe/G102_axe_V6_2.py
@@ -131,7 +131,7 @@ def aXe_noback_drizzle():
 
     # Running axecore:
     # ============================
-    if os.path.isfile("F110W_drz.fits"):
+    if os.path.isfile("DATA/DIRECT_GRISM/F110W_drz.fits"):
         print """
         --> axecore(inlist=GRISM+"_axeprep.lis", configs=conf_file, back="NO",
         extrfwhm=9.0, backfwhm=3.0, drzfwhm=4.0,
@@ -149,7 +149,7 @@ def aXe_noback_drizzle():
             lambda_psf=1153.0, np=30, interp=1, smooth_length=0, smooth_fwhm=0.0,
             spectr="YES",  adj_sens="YES", weights="YES", sampling="drizzle")
     else:
-        if os.path.isfile("F140W_drz.fits"):
+        if os.path.isfile("DATA/DIRECT_GRISM/F140W_drz.fits"):
             print """
             --> axecore(inlist=GRISM+"_axeprep.lis", configs=conf_file, back="NO",
             extrfwhm=9.0, backfwhm=3.0, drzfwhm=4.0,


### PR DESCRIPTION
G102_axe_V6.2.py changes to the parent directory, ParXXX, before running axecore. It checks for the direct images to determine which lambda_psf to use with axecore (used in petcont). However, it was looking in the wrong directory and so running axecore with lambda_psf set for F160W every time. This may not affect the results, but just in case.